### PR TITLE
Move toward a purer Collection monad

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -51,7 +51,7 @@ class Collection extends Monad
      */
     public function bind(callable $transform)
     {
-        $results = self::concat(array_map(static::unit, array_map($transform, $this->value)));
+        $results = array_map($transform, $this->value);
         return static::unit(...$results);
     }
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -47,7 +47,7 @@ class Collection extends Monad
      * Apply a transformation to each item of the monad.
      *
      * @param callable $transform
-     * @return Collection|Monad
+     * @return Collection
      */
     public function bind(callable $transform)
     {

--- a/src/CollectionT.php
+++ b/src/CollectionT.php
@@ -1,0 +1,31 @@
+<?php namespace Phonad;
+
+class CollectionT extends MonadT {
+    public function __construct(...$monads) {
+        $this->monads = $monads;
+    }
+
+    public static function unit(...$monads) {
+        return new static(...$monads);
+    }
+
+    public function bind(callable $transform)
+    {
+        $results = array_map(function ($monad) use ($transform) {
+            return $monad->bind($transform);
+        }, $this->monads);
+        return static::unit(...$results);
+    }
+
+    public static function lift(Monad $monad)
+    {
+        // Doesn't seem to mean much in PHP.
+    }
+
+    public function unpack()
+    {
+        return array_map(function ($monad) {
+            return $monad->unpack();
+        }, $this->monads);
+    }
+}

--- a/src/Monad.php
+++ b/src/Monad.php
@@ -52,12 +52,6 @@ abstract class Monad
      */
     public static function unit(...$value)
     {
-        if (count($value) === 1 && current($value) instanceof Monad) {
-            return current($value);
-        }
-        if (count($value) === 1 && is_null(current($value))) {
-            return new Nothing;
-        }
         return new static(...$value);
     }
 

--- a/src/MonadT.php
+++ b/src/MonadT.php
@@ -1,0 +1,8 @@
+<?php namespace Phonad;
+
+abstract class MonadT {
+    abstract public static function unit(...$monads);
+    abstract public function bind(callable $transform);
+    abstract public static function lift(Monad $monad);
+    abstract public function unpack();
+}

--- a/src/Option.php
+++ b/src/Option.php
@@ -35,13 +35,13 @@ class Option extends Monad
      * Apply a transformation to the monad.
      *
      * @param callable $transform
-     * @return Option|Nothing|Monad
+     * @return Option|Nothing
      */
     public function bind(callable $transform)
     {
         $result = $transform($this->value);
-        return ($result instanceof Option)
-          ? $result
+        return (is_null($result))
+          ? Nothing::unit($result)
           : static::unit($result);
     }
 }

--- a/src/OptionT.php
+++ b/src/OptionT.php
@@ -1,0 +1,28 @@
+<?php namespace Phonad;
+
+class OptionT extends MonadT {
+    public function __construct(Monad $monad) {
+        $this->monad = $monad;
+    }
+
+    public static function unit(...$monads) {
+        return new static(...$monads);
+    }
+
+    public function bind(callable $transform) {
+        $result = $this->monad->bind($transform);
+        if (is_null($result->unpack())) {
+            return new Nothing;
+        }
+        return static::unit($result);
+    }
+
+    public static function lift(Monad $monad) {
+        // Doesn't seem to mean much in PHP.
+    }
+
+    public function unpack()
+    {
+        return $this->monad->unpack();
+    }
+}

--- a/src/Traits/Collection.php
+++ b/src/Traits/Collection.php
@@ -21,21 +21,4 @@ trait Collection
             : null;
         };
     }
-
-    /**
-     * concat joins an array of values into a single array of unpacked values.
-     *
-     * Concat handles a unit of Nothing as a special case, ignoring it.
-     *
-     * @param $list array
-     * @return array
-     */
-    public static function concat($list)
-    {
-        return array_reduce($list, function ($carry, $item) {
-            return ($item instanceof Nothing || is_null($item))
-                ? $carry
-                : array_merge($carry, Utilities::maybeUnpack($item));
-        }, []);
-    }
 }

--- a/src/Until.php
+++ b/src/Until.php
@@ -35,14 +35,14 @@ class Until extends Monad
      * Apply a transformation to the monad.
      *
      * @param callable $transform
-     * @return Until|Something|Monad
+     * @return Until|Something
      */
     public function bind(callable $transform)
     {
         $result = $transform($this->value);
 
-        if ($result instanceof Nothing || is_null($result)) {
-            return new Until($this->value);
+        if (is_null($result)) {
+            return $this;
         }
         return Something::unit($result);
     }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -36,37 +36,6 @@ class CollectionTest extends TestCase
 
     /**
      * @group operation
-     * @group concat
-     */
-    public function testConcatOnArrays()
-    {
-        $arrays = [
-          new Collection('one'),
-          new Collection('two'),
-          new Collection('three'),
-        ];
-        $result = Collection::concat($arrays);
-        $this->assertEquals(['one', 'two', 'three'], $result);
-    }
-
-    /**
-     * @group operation
-     * @group concat
-     */
-    public function testConcatHandlesNone()
-    {
-        $arrays = [
-          new Collection('one'),
-          new Collection('two'),
-          new Nothing,
-          new Collection('three'),
-        ];
-        $result = Collection::concat($arrays);
-        $this->assertEquals(['one', 'two', 'three'], $result);
-    }
-
-    /**
-     * @group operation
      * @group at
      */
     public function testAtHandlesArrays()
@@ -83,7 +52,7 @@ class CollectionTest extends TestCase
           ->at('email')
           ->unpack();
 
-        $this->assertEquals(['steve@example.test', 'ellen@example.test'], $emails);
+        $this->assertEquals(['steve@example.test', null, 'ellen@example.test'], $emails);
     }
 
     /**
@@ -104,7 +73,7 @@ class CollectionTest extends TestCase
           ->at('email')
           ->unpack();
 
-        $this->assertEquals(['steve@example.test', 'ellen@example.test'], $emails);
+        $this->assertEquals(['steve@example.test', null, 'ellen@example.test'], $emails);
     }
 
     /**
@@ -126,7 +95,7 @@ class CollectionTest extends TestCase
           ->at('first')
           ->unpack();
 
-        $this->assertEquals([], $emails);
+        $this->assertEquals([null, null, null], $emails);
     }
 
     /**
@@ -144,10 +113,17 @@ class CollectionTest extends TestCase
         $booksList = Collection::unit(...$books);
         $theRightBook = $booksList
           ->where(function ($element) {
-              return $element['title'] === 'War and Peace';
+              return $element['title'] === 'Another Title';
           })
           ->unpack();
 
-        $this->assertEquals($books[0], current($theRightBook));
+        $this->assertEquals(
+            [
+                null,
+                $books[1],
+                null,
+            ],
+            $theRightBook
+        );
     }
 }

--- a/tests/IdentityTest.php
+++ b/tests/IdentityTest.php
@@ -28,30 +28,11 @@ class IdentityTest extends TestCase
     /**
      * @group monad
      */
-    public function testDoesntWrapSelf()
-    {
-        $value = Identity::unit(3);
-        $newValue = Identity::unit($value);
-        $this->assertEquals(3, $newValue->unpack());
-    }
-
-    /**
-     * @group monad
-     */
     public function testCallFailsOnUndefinedMethod()
     {
         $this->expectException(MethodNotFoundException::class);
         $value = Identity::unit(3);
         $value->foo(3);
-    }
-
-    /**
-     * @group monad
-     */
-    public function testConstructsNothingFromNull()
-    {
-        $monad = Identity::unit(null);
-        $this->assertInstanceOf(Nothing::class, $monad);
     }
 
     /**


### PR DESCRIPTION
Right now, Collection does the job of 'Collection' and 'Option' all in one -- this isn't really the desired state. Eventually it'd be preferable to keep the monads pure and to use some transformation to make them play more nicely together (i.e. chaining a Collection and an Option monad together to get filtered collections and such). For now, this Collection monad will return nulls.